### PR TITLE
Add trailing "/"s to keep Netlify proxying happy

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
   ## Specifications
 
   ### Core Schemas
-  <a class=spec href="core/v0.1">
+  <a class=spec href="core/v0.1/">
     <span class=name>core</span>
     <span class=tag>
       GraphQL schemas with interoperable metadata
@@ -124,7 +124,7 @@
   All other specifications in this library are core-compliant specs, designed to be referenced from core schemas.
 
   ### Joining and Linking
-  <a class=spec href="join/v0.1">
+  <a class=spec href="join/v0.1/">
     <span class=name>join</span>
     <span class=tag>
       for joining subgraphs into a supergraph


### PR DESCRIPTION
Without trailing "/"s, a redirect happens when accessing spec URLs, which leads to our Netlify proxying breaking. These changes make sure https://specs.apollo.dev is used for all specs URLs.