### PR TITLE
Fix formatting of "Ignore meaningless URL components" in core

### DIFF
--- a/anatomy.css
+++ b/anatomy.css
@@ -42,7 +42,7 @@ code.anatomy span > aside {
   top: 100%;
   left: 0;
   font-size: 50%;
-  width: 100%;
+  width: calc(100% - 8px);
   display: block;
   border-bottom: 1px solid var(--color);
   border-left: 1px solid var(--color);


### PR DESCRIPTION
The old version made it look like the identity and name included the slash before the version.

The fix is to cancel out the horizontal padding when calculating the width.