### PR TITLE
Setup Netlify

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,24 @@
+# Netlify Admin: https://app.netlify.com/sites/apollo-specs/
+#
+# Docs: https://docs.netlify.com/routing/redirects/
+
+# The Netlify site URLs are of a known shape, based on the branches of the
+# GitHub repository that they are connected to:
+#
+# Example:
+#   https://{normalized-branch-name}--{netlify-site-name}.netlify.app/
+#
+#  normalized-branch-name: converts dots to dashes, and other transforms.
+#  netlify-site-name: the name defined in the Netlify UI's General settings.
+
+# Core
+# ----------
+# GitHub: https://github.com/apollo-specs/core
+# Netlify: https://app.netlify.com/sites/apollo-specs-core/
+/core/v0.1/* https://v0-1--apollo-specs-core.netlify.app/:splat 200!
+
+# Join
+# ----------
+# GitHub: https://github.com/apollo-specs/join
+# Netlify: https://app.netlify.com/sites/apollo-specs-join/
+/join/v0.1/* https://v0-1--apollo-specs-join.netlify.app/:splat 200!

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+# Netlify Admin: https://app.netlify.com/sites/apollo-specs/
+# Docs: https://docs.netlify.com/configure-builds/file-based-configuration/
+
+[build]
+  # This site has no build step at the moment.  We just publish the contents.
+  publish = "/"
+
+# Redirects are handled in the ./_redirects file, which has a simple format


### PR DESCRIPTION
> This is part of a multi-step migration, outlined in:
>
> * https://github.com/apollo-specs/apollo-specs.github.io/issues/6
>
> This shouldn't merge until the right point in that flow (though it's very early on, indeed, and it won't break anything if it merges), but perhaps review that in conjunction with this.


This sets up the Netlify configuration for this site, and allows the beginning of the migration from both GitHub pages to the standard way we deploy website properties across Apollo: Netlify.

The site is already in Netlify at:
  https://app.netlify.com/sites/apollo-specs-core/

While the website-router is currently used for the specs.apollo.dev domain, that was only a temporary configuration.  This root specs site is intended to become the "proxier" for the other specs, hence the proxy rules that lie within this commit.